### PR TITLE
Adjust confluence timeout limit

### DIFF
--- a/full
+++ b/full
@@ -6,7 +6,7 @@ if not array.includes(array.from("1", "5"), timeframe.period)
 
 max_display = input.int(30, "Max Elementos", minval=1, maxval=500)
 fvg_duration = input.int(20, "Duración FVG (min)", minval=5, maxval=100)
-confluence_timeout = input.int(30, "Tiempo límite confluencia (min)", minval=10, maxval=120)
+confluence_timeout = input.int(30, "Tiempo límite confluencia (min)", minval=10, maxval=900)
 stop_loss_multiplier = input.float(1.0, "Multiplicador Stop Loss", minval=0.1, maxval=5.0, step=0.1)
 tp_multiplier = input.float(1.0, "Multiplicador TP (x Stop Loss)", minval=0.5, maxval=5.0, step=0.5)
 risk_input = input.float(5.0, "Riesgo por Operación", minval=0.1, maxval=100.0, step=0.1)


### PR DESCRIPTION
## Summary
- extend max value allowed for `confluence_timeout` from 120 to 900

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a0e2ff8e08325b3704dd6d69cdd3e